### PR TITLE
add deterministic certificates

### DIFF
--- a/templates/certtool.cfg.erb
+++ b/templates/certtool.cfg.erb
@@ -89,3 +89,11 @@ crl_number = <%= @crl_number %>
 <% if defined?(@pkcs12_key_name) -%>
 pkcs12_key_name = "<%= @pkcs12_key_name %>"
 <% end -%>
+
+<% if defined?(@activation_date) -%>
+activation_date = "<%= @activation_date %>"
+<% end -%>
+
+<% if defined?(@expiration_date) -%>
+expiration_date = "<%= @expiration_date %>"
+<% end -%>


### PR DESCRIPTION
This PR adds the ability to generate deterministic certificates through the use of a seed, serial, and activation start / end pair.
The seed determines the random seed to prime the certificate while the serial determines the iteration from the seed to use.

An example of this is shown below:

```pp
# Set up the root CA
  CertTool::Cert {
    ...

    # Deterministically generate the cert
    seed => Sensitive('Some seed here'),
    serial => 1,
    activation_date => '2021-12-19 00:00:00 UTC',
    expiration_date => '2022-12-19 00:00:00 UTC',
}
```